### PR TITLE
English Siri Voice Commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,35 @@ Because this plugin's base was taken from [homebridge-netatmo](https://github.co
 3. On the following page, enter a name for your app. Any name can be chosen. All other fields of the form (like callback url, etc.) can be left blank.
 4. After successfully submitting the form the overview page of your app should show client id and secret.
 
-## Siri-Voicecommands
+## Siri Voice Commands
 
-Because the possible Siri-Commands depend on your home language it would suggest to check the official blog of eve first.
-For german language you find some infos in these two blog-posts:
-- https://blog.evehome.com/de/spass-mit-siri/
-- https://blog.evehome.com/de/tipp-siri-namen/
+Here are sample English voice commands:
+- How cool is it in the ROOM NAME?
+- How warm is it in the ROOM NAME?
+- How humid is it in the ROOM NAME?
+- What's the temperature in my ROOM NAME?
+- What's the humidity in my ROOM NAME?
+- What's the air quality in my ROOM NAME?
+- What's the CO2 level in my ROOM NAME?
+- What's the carbon dioxide level in my ROOM NAME?
 
-The english versions of these blog-posts are:
+Siri understands variations of each command:
+- What's the temperature ROOM NAME?
+- What's the temperature in ROOM NAME?
+- What's the temperature in my ROOM NAME?
+- What's the temperature in the ROOM NAME?
+- What's the temperature down in my ROOM NAME?
+- What's the temperature down in the ROOM NAME?
+
+Siri voice commands may vary by language. Since this plugin tries to mimic the Elgato Eve devices, you can search the Eve blog for articles listing voice commands in your language.
+
+Blog posts with English commands:
 - https://blog.evehome.com/fun-with-siri/
 - https://blog.evehome.com/tip-siri-names/
+
+Blog posts with German commands:
+- https://blog.evehome.com/de/spass-mit-siri/
+- https://blog.evehome.com/de/tipp-siri-namen/
 
 ## History
 


### PR DESCRIPTION
I have a Netatmo Weather Station (non-Homekit) with the following devices:

- Indoor Module (base station)
- Indoor Module (additional sensor)
- Outdoor Module
- Smart Rain Gauge

I would like to contribute an update to the English README file that contains a list of working English Siri Voice Commands. I have tested each of these Siri Voice Commands with my Netatmo sensors. 

If you reply to this PR with other known working Siri voice commands, I would be glad to test them and add them to my proposed README changes.

For Example - Is a voice command available to query the actual CO2 level? (e.g. 765 ppm) I can view the actual level in Home.app. If I ask "What is the CO2 level in the ROOM NAME", Siri replies with "Sensors detect normal Carbon Dioxide levels in the ROOM NAME.".

I really appreciate the work you put into this Homebridge Plugin. Thank you! Your plugin made it very easy to integrate the Netatmo Weather Station sensors with my other HomeKit devices. My rain gauge is listed as a non-supported device, so I was unable to test any rain-related voice commands.

Thanks again,
Jason