### PR TITLE
New Feature: Support for Netatmo's Air Quality Monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # homebridge-eveatmo
 
-This is a [homebridge](https://github.com/nfarina/homebridge) plugin which lets you integrate your non-HomeKit Netatmo Weatherstation into HomeKit.
+This is a [homebridge](https://github.com/nfarina/homebridge) plugin which lets you integrate your non-HomeKit Netatmo Weatherstation and Indoor Air Quality monitor into HomeKit.
 
 Whilst the original [homebridge-netatmo](https://github.com/planetk/homebridge-netatmo)-plugin goes a mostly HomeKit-standard approach (predefined services, characteristics, ...), this plugin tries to mimic the Elgato Eve devices as close as possible. 
 
@@ -20,6 +20,8 @@ You can also configure this plugin via [ConfigUI-X's settings](https://github.co
             "name": "eveatmo platform",
             "extra_co2_sensor": false,
             "co2_alert_threshold": 1000,
+            "weatherstation": true,
+            "airquality": false,
             "ttl": 540,
             "auth": {
     	        "client_id": "XXXXX Create at https://dev.netatmo.com/",
@@ -32,6 +34,8 @@ You can also configure this plugin via [ConfigUI-X's settings](https://github.co
 
 ```
 
+- **weatherstation** Enables support for Netatmo's WeatherStation. Default value is *true*
+- **airquality** Enables support for Netatmo's Indoor Air Quality monitor. Default value is *false*
 - **extra_co2_sensor: (optional)** Adds an extra CO2 sensor which is available via Apple's stock Home.app, too. Default value is *false*
 - **co2_alert_threshold (optional):** Sets the co2-level [ppm] at which the sensors switch to alert-state
 - **ttl: (optional)** Seconds between two Netatmo API polls. Lower is not neccessarily better! The weatherstation itself collects one value per 5minutes, so going below 300s makes no sense. Default value is *540* (=9min)
@@ -85,6 +89,7 @@ see [HISTORY.md](https://github.com/skrollme/homebridge-eveatmo/blob/master/HIST
 - <del>adding CO2 [ppm] or maybe just "CO2 detected" to indoor devices</del>
 - <del>researching/testing/implementing Eve's history-functionality (see: [https://gist.github.com/0ff/668f4b7753c80ad7b60b](https://gist.github.com/0ff/668f4b7753c80ad7b60b))</del>
 - <del>Make CO2 trigger threshold configurable (see: https://github.com/skrollme/homebridge-eveatmo/issues/24)</del>
+- <del>Support Indoor Air Quality monitor (see: https://github.com/skrollme/homebridge-eveatmo/issues/51)</del>
 
 
 ## Thanks

--- a/accessory/eveatmo-room-accessory.js
+++ b/accessory/eveatmo-room-accessory.js
@@ -4,7 +4,6 @@ var homebridge;
 var Characteristic;
 var NetatmoAccessory;
 var path = require('path');
-const eveatmoNoise = require('../service/eveatmo-noise');
 var FakeGatoHistoryService;
 
 module.exports = function(pHomebridge) {
@@ -23,8 +22,8 @@ module.exports = function(pHomebridge) {
 				"netatmoType": deviceData.type,
 				"firmware": deviceData.firmware,
 				"name": deviceData._name || "Eveatmo " + netatmoDevice.deviceType + " " + deviceData._id,
-				"hasBattery": (deviceData.battery_vp)?true:false,
-				"hasPressure": (deviceData.data_type.indexOf("Pressure") >= 0)?true:false,
+				"hasBattery": (deviceData.battery_vp),
+				"hasPressure": (deviceData.data_type.indexOf("Pressure") >= 0),
 			};
 
 			super(homebridge, accessoryConfig, netatmoDevice);

--- a/accessory/eveatmo-room-accessory.js
+++ b/accessory/eveatmo-room-accessory.js
@@ -4,6 +4,7 @@ var homebridge;
 var Characteristic;
 var NetatmoAccessory;
 var path = require('path');
+const eveatmoNoise = require('../service/eveatmo-noise');
 var FakeGatoHistoryService;
 
 module.exports = function(pHomebridge) {
@@ -35,6 +36,7 @@ module.exports = function(pHomebridge) {
 			this.lowBattery = false;
 			this.airPressure = 1000;
 			this.humidity = 50;
+			this.noise = 40;
 
 			this.refreshData(function(err, data) {});
 		}
@@ -66,6 +68,10 @@ module.exports = function(pHomebridge) {
 					this.addService(serviceBattery);
 				}
 
+				var NoiseService = require(serviceDir + '/eveatmo-noise')(homebridge);
+				var serviceNoise = new NoiseService(this);
+				this.addService(serviceNoise);
+
                 this.historyService = new FakeGatoHistoryService("room", this, {storage:'fs'});
 
 			} catch (err) {
@@ -84,7 +90,7 @@ module.exports = function(pHomebridge) {
 			var weatherData = this.mapAccessoryDataToWeatherData(accessoryData);
 
             // testing, because it seems, that low co2 values cause gaps in history
-            weatherData["co2"] = Math.max(450,weatherData["co2"]);
+            weatherData["co2"] = Math.max(450, weatherData["co2"]);
 
             this.historyService.addEntry({
                 time: new Date().getTime() / 1000,
@@ -111,6 +117,9 @@ module.exports = function(pHomebridge) {
 				}
 				if (dashboardData.Humidity) {
 					result.humidity = dashboardData.Humidity;
+				}
+				if (dashboardData.Noise) {
+					result.noise = dashboardData.Noise;
 				}
 			}
 
@@ -140,6 +149,10 @@ module.exports = function(pHomebridge) {
 			}
 			if (weatherData.humidity && this.humidity != weatherData.humidity) {
 				this.humidity = weatherData.humidity;
+				dataChanged = true;
+			}
+			if (weatherData.noise && this.noise != weatherData.noise) {
+				this.noise = weatherData.noise;
 				dataChanged = true;
 			}
 			if (weatherData.batteryPercent && this.batteryPercent != weatherData.batteryPercent) {

--- a/config.schema.json
+++ b/config.schema.json
@@ -26,6 +26,18 @@
         "default": false,
         "description": "Adds an extra CO2 sensor for alerts"
       },
+      "weatherstation": {
+        "title": "Weatherstation",
+        "type": "boolean",
+        "default": true,
+        "description": "Activate Netatmo Weatherstation reporting"
+      },
+      "airquality": {
+        "title": "Air Quality Monitor",
+        "type": "boolean",
+        "default": false,
+        "description": "Activate Netatmo Air Quality Monitor reporting"
+      },
       "co2_alert_threshold": {
         "title": "CO2 alert threshold",
         "type": "integer",

--- a/device/airquality-device.js
+++ b/device/airquality-device.js
@@ -1,0 +1,56 @@
+'use strict';
+
+var NetatmoDevice = require("../lib/netatmo-device");
+
+var homebridge;
+var EveatmoRoomAccessory;
+
+module.exports = function(pHomebridge) {
+	if (pHomebridge && !homebridge) {
+		homebridge = pHomebridge;
+		EveatmoRoomAccessory = require("../accessory/eveatmo-room-accessory")(homebridge);
+	}
+
+	class AirQualityDeviceType extends NetatmoDevice {
+		constructor(log, api, config) {
+			super(log, api, config);
+			this.log.debug("Creating Air Quality Devices");
+			this.deviceType = "airquality";
+		}
+
+		loadDeviceData(callback) {
+			this.api.getHealthyHomeCoachData(function(err, devices) {
+				var deviceMap = {};
+				devices.forEach(function(device) {
+					deviceMap[device._id] = device;
+
+					if(this.config.module_suffix != "") {
+						device._name = "Air Quality " + this.config.module_suffix;
+					} else {
+						device._name = device.station_name + " Air Quality";
+					}
+				}.bind(this));
+				this.log.debug("Setting cache with key: "+this.deviceType);
+				this.cache.set(this.deviceType, deviceMap);
+				this.deviceData = deviceMap;
+				
+				if (this.accessories) {
+					this.accessories.forEach(function(accessory) {
+						accessory.notifyUpdate(this.deviceData);
+					}.bind(this));
+				}			
+				callback(null, this.deviceData);
+			}.bind(this));
+		}
+
+		buildAccessory(deviceData) {
+			if(deviceData.type == 'NHC') {
+				return new EveatmoRoomAccessory(deviceData, this);
+			}
+			return false;
+		}
+	}
+
+	return AirQualityDeviceType;
+
+};

--- a/index.js
+++ b/index.js
@@ -61,20 +61,25 @@ class EveatmoPlatform {
 		var calls = [];
 
 		try {
-			calls.push(function(callback) {
-				var DeviceType = require('./device/weatherstation-device.js')(homebridge);
-				var devType = new DeviceType(this.log, this.api, this.config);
-				devType.buildAccessoriesForDevices(function(err, deviceAccessories) {
-					callback(err, deviceAccessories);
-				});
-			}.bind(this));
-			calls.push(function(callback) {
-				var DeviceType = require('./device/airquality-device.js')(homebridge);
-				var devType = new DeviceType(this.log, this.api, this.config);
-				devType.buildAccessoriesForDevices(function(err, deviceAccessories) {
-					callback(err, deviceAccessories);
-				});
-			}.bind(this));
+			if(this.config.weatherstation) {
+				calls.push(function(callback) {
+					var DeviceType = require('./device/weatherstation-device.js')(homebridge);
+					var devType = new DeviceType(this.log, this.api, this.config);
+					devType.buildAccessoriesForDevices(function(err, deviceAccessories) {
+						callback(err, deviceAccessories);
+					});
+				}.bind(this));
+			}
+
+			if(this.config.airquality) {
+				calls.push(function(callback) {
+					var DeviceType = require('./device/airquality-device.js')(homebridge);
+					var devType = new DeviceType(this.log, this.api, this.config);
+					devType.buildAccessoriesForDevices(function(err, deviceAccessories) {
+						callback(err, deviceAccessories);
+					});
+				}.bind(this));
+			}	
 		} catch (err) {
 			this.log("Could not process device");
 			this.log(err);

--- a/index.js
+++ b/index.js
@@ -68,6 +68,13 @@ class EveatmoPlatform {
 					callback(err, deviceAccessories);
 				});
 			}.bind(this));
+			calls.push(function(callback) {
+				var DeviceType = require('./device/airquality-device.js')(homebridge);
+				var devType = new DeviceType(this.log, this.api, this.config);
+				devType.buildAccessoriesForDevices(function(err, deviceAccessories) {
+					callback(err, deviceAccessories);
+				});
+			}.bind(this));
 		} catch (err) {
 			this.log("Could not process device");
 			this.log(err);

--- a/lib/netatmo-api-mock.js
+++ b/lib/netatmo-api-mock.js
@@ -46,6 +46,23 @@ NetatmoAPIMock.prototype.getStationsData = function (options, callback) {
   }
 };
 
+NetatmoAPIMock.prototype.getHealthyHomeCoachData = function (options, callback) {
+  if (options != null && callback == null) {
+    callback = options;
+    options = null;
+  }
+  
+  var data = this.getMockData("gethomecoachsdata");
+  var devices = [];
+  if (data && data.body) {
+    devices = data.body.devices;
+  }
+
+  if (callback) {
+    return callback(null, devices);
+  }
+};
+
 NetatmoAPIMock.prototype.getThermostatsData = function (options, callback) {
   if (options != null && callback == null) {
     callback = options;

--- a/mockapi_calls/gethomecoachsdata-eveatmo.json
+++ b/mockapi_calls/gethomecoachsdata-eveatmo.json
@@ -1,0 +1,65 @@
+
+{
+	"body": {
+		"devices": [
+			{
+				"_id": "70:00:00:01:23:45",
+				"cipher_id": "enc:16:00",
+				"last_status_store": 1501492718,
+				"place": {
+					"altitude": 66,
+					"city": "Somewhere",
+					"country": "DE",
+					"timezone": "Europe/Berlin",
+					"location": [
+						8.00000,
+						52.00000
+					]
+				},
+				"station_name": "eveatmo",
+				"type": "NHC",
+				"dashboard_data": {
+                    "time_utc": 1608477101,
+                    "Temperature": 21.6,
+                    "CO2": 2396,
+                    "Humidity": 63,
+                    "Noise": 38,
+                    "Pressure": 1029.2,
+                    "AbsolutePressure": 1021.2,
+                    "health_idx": 2
+				},
+				"data_type": [
+                    "Temperature",
+                    "CO2",
+                    "Humidity",
+                    "Noise",
+                    "Pressure",
+                    "health_idx"
+                ],
+				"co2_calibrating": false,
+				"date_setup": 1414690069,
+				"last_setup": 1414690069,
+				"module_name": "Livingroom",
+				"firmware": 48,
+				"last_upgrade": 1532721662,
+                "reachable": true,
+				"wifi_status": 25
+			}
+		],
+		"user": {
+			"mail": "mail@example.com",
+			"administrative": {
+				"country": "DE",
+				"reg_locale": "de-DE",
+				"lang": "de-DE",
+				"unit": 0,
+				"windunit": 0,
+				"pressureunit": 0,
+				"feel_like_algo": 0
+			}
+		}
+	},
+	"status": "ok",
+	"time_exec": 0.07361102104187,
+	"time_server": 1501492826
+}

--- a/service/eveatmo-noise.js
+++ b/service/eveatmo-noise.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var homebridge;
+var Characteristic;
+
+const NOISE_LEVEL_STYPE_ID = "8C85FD40-EB20-45EE-86C5-BCADC773E580";
+const NOISE_LEVEL_CTYPE_ID = "2CD7B6FD-419A-4740-8995-E3BFE43735AB";
+
+module.exports = function(pHomebridge) {
+  if (pHomebridge && !homebridge) {
+    homebridge = pHomebridge;
+    Characteristic = homebridge.hap.Characteristic;
+  }
+
+  class NoiseCharacteristic extends Characteristic {
+    constructor(accessory) {
+      super('Noise Level', NOISE_LEVEL_CTYPE_ID);
+      this.setProps({
+        format: Characteristic.Formats.UINT8,
+        unit: "dB",
+        minValue: 0,
+        maxValue: 200,
+        minStep: 1,
+        perms: [
+          Characteristic.Perms.READ,
+          Characteristic.Perms.NOTIFY
+        ]
+      });
+      this.value = this.getDefaultValue();
+    }
+  }
+
+  class NoiseService extends homebridge.hap.Service {
+    constructor(accessory) {
+      super(accessory.name + " Noise", NOISE_LEVEL_STYPE_ID);
+      this.accessory = accessory;
+
+      this.addCharacteristic(NoiseCharacteristic)
+        .on('get', this.getNoise.bind(this))
+        .eventEnabled = true;
+
+      this.addOptionalCharacteristic(Characteristic.Name);
+    }
+
+    updateCharacteristics() {
+      this.getCharacteristic(NoiseCharacteristic)
+            .updateValue(this.accessory.noise);
+    }
+
+    getNoise(callback) {
+      this.accessory.refreshData(function(err, data) {
+        callback(err, this.accessory.noise);
+      }.bind(this));
+    }
+  }
+
+  return NoiseService;
+}; 


### PR DESCRIPTION
This pull request adds support for Netatmo's [Air Quality Monitor](https://www.netatmo.com/en-us/aircare/homecoach) - also known as HomeCoach.

It's based on the Smart Home Station already supported by this module and can be toggled on/off with the module's config (default state is off).

NPM module `netatmo` already supports the call for the correct API calls with `getHealthyHomeCoachData()`, which then proceeds to populate a Eve Home like device supported by Homebridge. Supports Noise data, that can be checked with an alternative app like **Eve Home**.