### PR TITLE
Added configuration switch for log output

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -50,6 +50,12 @@
         "type": "string",
         "description": "Suffix to the module name. Deletes the prepended Netatmo device name"
       },
+      "log_info_msg": {
+        "title": "Log info messages",
+        "type": "boolean",
+        "default": true,
+        "description": "Outputs log messages with loglevel set to info"
+      },      
       "auth": {
         "title": "Netatmo credentials",
         "type": "object",

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ class EveatmoPlatform {
         this.config.co2_alert_threshold = typeof config.co2_alert_threshold !== 'undefined' ? parseInt(config.co2_alert_threshold) : 1000;
 
 		this.config.module_suffix = typeof config.module_suffix !== 'undefined' ? config.module_suffix : '';
+        this.config.log_info_msg = typeof config.log_info_msg !== 'undefined' ? Boolean(config.log_info_msg) : true;
 
 		// If this log message is not seen, most likely the config.js is not found.
 		this.log.debug('Creating EveatmoPlatform');

--- a/lib/netatmo-device.js
+++ b/lib/netatmo-device.js
@@ -48,7 +48,9 @@ class NetatmoDevice {
 		this.cache.get((this.deviceType), function(err, data) {
 			if (!err) {
 				if (data == undefined || data === null || force === true) {
-					this.log("Loading new data from API for: " + this.deviceType);
+					if (this.config.log_info_msg){
+						this.log("Loading new data from API for: " + this.deviceType);
+					}
 					if(force) {
 						this.log.debug("Reloading forced for: " + this.deviceType);
 						this.loadDeviceData(function(err, data) {


### PR DESCRIPTION
Created PR for feature request #63. It adds an additional plugin configuration switch to enable/disable log messages with log level *info*. The default setting is _true_ (=enabled). This preserves the existing behavior of the plugin.

@skrollme : please review. Looking forward to your comments. Thank you!