### PR TITLE
Added flag to enable/disable AirQuality sensor for indoor module

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 ## version history
 
+## 1.1.1
+- Add new flag to enable/disable AirQuality sensor for indoor modules
+
 ### 1.1.0
 - allows new auth method (via refreshtoken) and old one (via password)
   - added config-schema to configure this via UI   

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ You can also configure this plugin via [ConfigUI-X's settings](https://github.co
 
 - **weatherstation** Enables support for Netatmo's WeatherStation. Default value is *true*
 - **airquality** Enables support for Netatmo's Indoor Air Quality monitor. Default value is *false*
+- **extra_aq_sensor: (optional)** Adds an extra AirQuality sensor which is available via Apple's stock Home.app, reporting CO2 level. Default value is *false*
 - **extra_co2_sensor: (optional)** Adds an extra CO2 sensor which is available via Apple's stock Home.app, too. Default value is *false*
 - **co2_alert_threshold (optional):** Sets the co2-level [ppm] at which the sensors switch to alert-state
 - **ttl: (optional)** Seconds between two Netatmo API polls. Lower is not neccessarily better! The weatherstation itself collects one value per 5minutes, so going below 300s makes no sense. Default value is *540* (=9min)

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Cheers go to:
 - C. Schneider :beers:
 - S. Eisenkrämer :beers:
 - C. Kowalczyk :beers:
+- C. Lorenz 💰
 
 
 

--- a/accessory/eveatmo-room-accessory.js
+++ b/accessory/eveatmo-room-accessory.js
@@ -50,10 +50,12 @@ module.exports = function(pHomebridge) {
 				var HumidityService = require(serviceDir + '/eveatmo-humidity')(homebridge);
 				var serviceHumidity = new HumidityService(this);
 				this.addService(serviceHumidity);
-
-				var EveatmoRoomAirqualityService = require(serviceDir + '/eveatmo-room-airquality')(homebridge);
-                var serviceAirquality = new EveatmoRoomAirqualityService(this);
-                this.addService(serviceAirquality);
+				
+				if(this.config.extra_aq_sensor) {
+					var EveatmoRoomAirqualityService = require(serviceDir + '/eveatmo-room-airquality')(homebridge);
+					var serviceAirquality = new EveatmoRoomAirqualityService(this);
+					this.addService(serviceAirquality);
+				}
 
                 if(this.config.extra_co2_sensor) {
                     var EveatmoRoomCo2Service = require(serviceDir + '/eveatmo-co2')(homebridge);

--- a/config.schema.json
+++ b/config.schema.json
@@ -20,6 +20,12 @@
         "minimum": 300,
         "description": "Seconds between two Netatmo API polls (default 540)"
       },
+      "extra_aq_sensor": {
+        "title": "Extra AirQuality sensor",
+        "type": "boolean",
+        "default": false,
+        "description": "Adds an extra AirQuality sensor reporting CO2 level"
+      },
       "extra_co2_sensor": {
         "title": "Extra CO2 sensor",
         "type": "boolean",

--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ class EveatmoPlatform {
 		this.foundAccessories = [];
 
 		this.config.weatherstation = typeof config.weatherstation !== 'undefined' ? Boolean(config.weatherstation) : true;
-        this.config.extra_co2_sensor = typeof config.extra_co2_sensor !== 'undefined' ? Boolean(config.extra_co2_sensor) : false;
+        this.config.extra_aq_sensor = typeof config.extra_aq_sensor !== 'undefined' ? Boolean(config.extra_aq_sensor) : false;
+		this.config.extra_co2_sensor = typeof config.extra_co2_sensor !== 'undefined' ? Boolean(config.extra_co2_sensor) : false;
         this.config.co2_alert_threshold = typeof config.co2_alert_threshold !== 'undefined' ? parseInt(config.co2_alert_threshold) : 1000;
 
 		this.config.module_suffix = typeof config.module_suffix !== 'undefined' ? config.module_suffix : '';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "homebridge-eveatmo",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Homebridge plugin which adds a Netatmo weatherstation as HomeKit device and tries to act like Elgato Eve Room/Weather",
 	"license": "ISC",
 	"keywords": [


### PR DESCRIPTION
I added an additional config item to disable the AirQuality sensor that is automatically created (reporting CO2 level), so that you can decide to show only the CO2 sensor. 
In most Homekit implementations, CO2 level is only reported within the sensor and not as part of AirQuality. This way you can do both