### PR TITLE
Netatmo API - API Domain Name Change

### DIFF
--- a/lib/netatmo-api.js
+++ b/lib/netatmo-api.js
@@ -4,7 +4,7 @@ var request = require('request');
 var moment = require('moment');
 var fs = require('fs');
 
-const BASE_URL = 'https://api.netatmo.net';
+const BASE_URL = 'https://api.netatmo.com';
 
 var client_id;
 var client_secret;


### PR DESCRIPTION
Updating API endpoint hostname, per the following email I received from Netatmo today. I confirmed both hostnames (OLD api.netatmo.net and NEW api.netatmo.com) do resolve to the exact same Azure IP address.

> **Netatmo API - API Domain Name Change**
>  
> **Dear Netatmo developer,**
> We hope this message finds you well.
>  
> We are writing to inform you of an upcoming change to our API domain configuration. As part of our ongoing efforts to streamline and improve our services, we will be retiring the domain api.netatmo.net and consolidating all API traffic under the existing domain api.netatmo.com.
>  
> **Effective Date**:September 8, 2025
>  
> To ensure uninterrupted service, we kindly ask you to update your applications to use api.netatmo.com exclusively before the above date. The structure and functionality of the API remain unchanged — only the domain name is affected.
>   
> Sincerely,
> Legrand - Netatmo - Bticino