### PR TITLE
Add automated test suite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,3 +27,6 @@ jobs:
 
       - name: Lint the project
         run: npm run lint
+
+      - name: Run tests
+        run: npm test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A Homebridge plugin (`homebridge-eveatmo`) that exposes a Netatmo Weatherstation and/or Indoor Air Quality monitor as HomeKit accessories, mimicking the look and feel of Elgato Eve Room/Weather devices (custom Eve characteristics, Eve history via `fakegato-history`) rather than using stock HomeKit sensor services.
+
+Plain JavaScript (CommonJS, `require`/`module.exports`), not TypeScript, despite `typescript`/`typescript-eslint` being devDependencies — those are only used to power the ESLint flat config's type-aware rules.
+
+## Commands
+
+```bash
+npm run lint     # eslint . --max-warnings=0
+npm run fix      # eslint . --max-warnings=0 --fix
+npm test         # node --test
+```
+
+There is no build step. Tests use Node's built-in `node:test` runner against the real `@homebridge/hap-nodejs` (no hand-built HAP stub) — see `test/` (mirrors `device/`/`accessory/` source layout) and `test-helpers/` (shared bootstrap; deliberately kept outside any directory named `test`, since `node --test`'s default discovery recursively treats every `.js` file under a `test/`-named directory as a test file). CI (`.github/workflows/build.yml`) runs `npm install` + `npm run lint` + `npm test` on Node 20.x/22.x/24.x for pushes to `master`/`develop` and PRs.
+
+To manually exercise the plugin without a real Netatmo account, set `"mockapi": "eveatmo"` in the platform config — this routes API calls to `lib/netatmo-api-mock.js`, which reads fixture JSON from `mockapi_calls/*-<mockapi value>.json` (falls back to `*-default.json` if the named fixture is missing).
+
+## Architecture
+
+Everything is wired together through `homebridge`'s `hap` object, which is only available once Homebridge calls the plugin's export function. Because of this, almost every file in this repo follows the same shape:
+
+```js
+module.exports = function (pHomebridge) {
+  if (pHomebridge && !homebridge) {
+    homebridge = pHomebridge;
+    // require() sibling modules here, passing `homebridge` through
+  }
+  class Something extends SomeHapClass { ... }
+  return Something;
+};
+```
+
+Modules are required and instantiated lazily inside constructors/builders (not at top-level) specifically so `homebridge.hap.*` classes exist before they're subclassed. When adding a new accessory/service, follow this same factory-function pattern rather than requiring `homebridge.hap` at module load time.
+
+### Layers (top to bottom)
+
+1. **`index.js`** — registers the `eveatmo` platform. `EveatmoPlatform` validates config (`auth` block, `grant_type`), constructs the Netatmo API client (real or mock), and in `accessories()` fans out to one "device type" per enabled feature (`weatherstation`, `airquality`) via `async.parallel`, retrying once after 30s on failure.
+
+2. **`lib/netatmo-api.js`** — hand-maintained, promise-free (callback + EventEmitter) client for the Netatmo REST API (axios under the hood). Handles both `refresh_token` and deprecated `password` OAuth grants; persists refreshed tokens to `<homebridge-storage>/netatmo-token.json` and proactively refreshes 5 minutes before expiry. This file is a maintained fork of the abandoned `netatmo` npm package — treat API surface changes here as intentional, not accidental duplication. `lib/netatmo-api-mock.js` is a drop-in replacement with the same method names, backed by static fixtures.
+
+3. **`device/*-device.js`** (`WeatherstationDeviceType`, `AirQualityDeviceType`) — extend `lib/netatmo-device.js`'s `NetatmoDevice` base class. Each owns a `NodeCache` (TTL from config, min 300s) for the raw Netatmo device map, a `setInterval` poll loop that pushes fresh data to all built accessories, and a `buildAccessory(deviceData)` factory that maps a Netatmo module `type` string (e.g. `NAMain`, `NAModule1`) to an accessory class. Whitelist/blacklist filtering by device ID happens here in `buildAccessories()`.
+
+4. **`accessory/*-accessory.js`** (Room, Weather, Rain, Wind) — extend `lib/netatmo-accessory.js`'s `NetatmoAccessory` (itself a `homebridge.hap.Accessory` subclass). Each builds its own set of HAP services in `buildServices()`, tracks the latest sensor values as plain instance properties, and implements `notifyUpdate(deviceData, force)` to map raw Netatmo `dashboard_data` fields into those properties and push changes to services via `updateCharacteristics()`. Also owns a `fakegato-history` service instance for Eve app history graphs.
+
+5. **`service/*.js`** — one file per HAP service/characteristic group (temperature, humidity, CO2, battery, noise, rain, wind, pressure, room air quality). Each is a `homebridge.hap.Service` subclass wired to its owning accessory; `get` handlers read from the accessory's cached properties (triggering a `refreshData()` call), and `updateCharacteristics()` pushes accessory state into HAP characteristics after a data refresh.
+
+### Data flow
+
+Netatmo API → `device/*` (cache + poll timer) → `accessory/*.notifyUpdate()` (maps `dashboard_data` → instance fields, records fakegato history entry) → `service/*.updateCharacteristics()` (pushes fields into HAP characteristics). Reads (HomeKit `get` on a characteristic) go the other way: `service.getX()` → `accessory.refreshData()` → `device.refreshDeviceData()` (serves from cache unless forced/expired).
+
+### Config-driven behavior worth knowing
+
+- `weatherstation` / `airquality` toggle which device types load at all (`index.js#loadDevices`).
+- `extra_aq_sensor` / `extra_co2_sensor` add optional extra HAP services on room accessories (`accessory/eveatmo-room-accessory.js#buildServices`).
+- `module_suffix`: when set, accessory names use `<module name> <suffix>` instead of `<station name> <module name>`, to dodge HomeKit's rejection of invalid characters sometimes present in Netatmo station names.
+- `whitelist` / `blacklist`: arrays of Netatmo device/module MAC-like IDs; enforced in `lib/netatmo-device.js#buildAccessories`. A non-empty whitelist excludes everything not listed.
+- `ttl`: poll interval in seconds, clamped to a 300s minimum (the station itself only samples every 5 minutes).
+
+## Style
+
+ESLint (flat config, `eslint.config.js`) enforces: single quotes, 2-space indent, required semicolons, Unix line endings, trailing commas on multiline, `curly: all`, `eqeqeq: smart`, max line length 200 (warning). Run `npm run fix` before committing to auto-fix most violations; `npm run lint` must pass with zero warnings for CI to go green.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,12 @@ npm run fix      # eslint . --max-warnings=0 --fix
 npm test         # node --test
 ```
 
-There is no build step. Tests use Node's built-in `node:test` runner against the real `@homebridge/hap-nodejs` (no hand-built HAP stub) — see `test/` (mirrors `device/`/`accessory/` source layout) and `test-helpers/` (shared bootstrap; deliberately kept outside any directory named `test`, since `node --test`'s default discovery recursively treats every `.js` file under a `test/`-named directory as a test file). CI (`.github/workflows/build.yml`) runs `npm install` + `npm run lint` + `npm test` on Node 20.x/22.x/24.x for pushes to `master`/`develop` and PRs.
+There is no build step. Tests use Node's built-in `node:test` runner — see `test/` (mirrors the source layout: `device/`, `accessory/`, `lib/`, plus `index.test.js` at the root) and `test-helpers/` (shared bootstrap; deliberately kept outside any directory named `test`, since `node --test`'s default discovery recursively treats every `.js` file under a `test/`-named directory as a test file). Two distinct mocking styles are used depending on the layer:
+
+- `device/`/`accessory/` tests (which exercise `service/*.js` indirectly, through the accessories that build them) run against the real `@homebridge/hap-nodejs` (no hand-built HAP stub), with `fakegato-history` neutralized via a `require.cache` substitution (`test-helpers/stub-fakegato-history.js`) since it touches real disk/timers even at construction time.
+- `lib/netatmo-api.js` tests stub `axios` the same way (`test-helpers/stub-axios.js`) rather than hitting real HTTP — that module's public methods and its module-level (not per-instance!) auth state make it necessary to keep each auth scenario in its own test file, one process per file.
+
+`index.js`'s `EveatmoPlatform` class isn't exported directly — capture it via a fake `homebridge.registerPlatform` (`test-helpers/load-platform.js`). Note: `EveatmoPlatform.accessories()` is not covered end-to-end, because the device instances it builds internally start an un-`unref()`'d poll `setInterval` with no way to reach in and clear it from outside — calling it in a test hangs the process. CI (`.github/workflows/build.yml`) runs `npm install` + `npm run lint` + `npm test` on Node 20.x/22.x/24.x for pushes to `master`/`develop` and PRs.
 
 To manually exercise the plugin without a real Netatmo account, set `"mockapi": "eveatmo"` in the platform config — this routes API calls to `lib/netatmo-api-mock.js`, which reads fixture JSON from `mockapi_calls/*-<mockapi value>.json` (falls back to `*-default.json` if the named fixture is missing).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "homebridge-eveatmo",
-	"version": "1.3.0-beta4",
+	"version": "1.3.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "homebridge-eveatmo",
-			"version": "1.3.0-beta4",
+			"version": "1.3.5",
 			"funding": [
 				{
 					"type": "github",
@@ -27,6 +27,7 @@
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.14.0",
+				"@homebridge/hap-nodejs": "2.1.0",
 				"@types/eslint__js": "^8.42.3",
 				"@types/node": "^22.8.6",
 				"eslint": "^10.0.2",
@@ -36,7 +37,7 @@
 				"typescript-eslint": "^8.12.2"
 			},
 			"engines": {
-				"homebridge": "^1.6.0 || ^2.0.0-beta.0",
+				"homebridge": "^1.6.0 || ^2.0.0",
 				"node": "^24 || 22.14.0 || 22 || ^20 || ^18"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -39,10 +39,12 @@
 	"homepage": "https://github.com/skrollme/homebridge-eveatmo#readme",
 	"scripts": {
 		"lint": "eslint . --max-warnings=0",
-		"fix": "eslint . --max-warnings=0 --fix"
+		"fix": "eslint . --max-warnings=0 --fix",
+		"test": "node --test"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.14.0",
+		"@homebridge/hap-nodejs": "2.1.0",
 		"@types/eslint__js": "^8.42.3",
 		"@types/node": "^22.8.6",
 		"eslint": "^10.0.2",

--- a/test-helpers/fake-axios.js
+++ b/test-helpers/fake-axios.js
@@ -1,0 +1,10 @@
+'use strict';
+
+function createFakeAxios() {
+  return {
+    post: () => Promise.reject(new Error('axios.post not stubbed for this call')),
+    get: () => Promise.reject(new Error('axios.get not stubbed for this call')),
+  };
+}
+
+module.exports = { createFakeAxios };

--- a/test-helpers/hap.js
+++ b/test-helpers/hap.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/* eslint-disable-next-line @typescript-eslint/no-require-imports */
+const HAPNodeJS = require('@homebridge/hap-nodejs');
+
+module.exports = {
+  homebridge: { hap: HAPNodeJS },
+  hap: HAPNodeJS,
+};

--- a/test-helpers/load-platform.js
+++ b/test-helpers/load-platform.js
@@ -1,0 +1,17 @@
+'use strict';
+
+function loadPlatform(homebridgeStub) {
+  let CapturedPlatform = null;
+  const stub = Object.assign({}, homebridgeStub, {
+    registerPlatform(pluginName, platformName, PlatformClass) {
+      CapturedPlatform = PlatformClass;
+    },
+  });
+
+  /* eslint-disable-next-line @typescript-eslint/no-require-imports */
+  require('../index')(stub);
+
+  return CapturedPlatform;
+}
+
+module.exports = { loadPlatform };

--- a/test-helpers/log.js
+++ b/test-helpers/log.js
@@ -1,0 +1,12 @@
+'use strict';
+
+function createLog() {
+  const log = () => {};
+  log.debug = () => {};
+  log.info = () => {};
+  log.warn = () => {};
+  log.error = () => {};
+  return log;
+}
+
+module.exports = { createLog };

--- a/test-helpers/log.js
+++ b/test-helpers/log.js
@@ -9,4 +9,20 @@ function createLog() {
   return log;
 }
 
-module.exports = { createLog };
+function createRecordingLog() {
+  const calls = [];
+  function record(level) {
+    return (...args) => {
+      calls.push({ level, args });
+    };
+  }
+  const log = record('log');
+  log.debug = record('debug');
+  log.info = record('info');
+  log.warn = record('warn');
+  log.error = record('error');
+  log.calls = calls;
+  return log;
+}
+
+module.exports = { createLog, createRecordingLog };

--- a/test-helpers/netatmo-device-stub.js
+++ b/test-helpers/netatmo-device-stub.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/* eslint-disable-next-line @typescript-eslint/no-require-imports */
+const { createLog } = require('./log');
+
+function createNetatmoDeviceStub(deviceDataMap, config) {
+  return {
+    deviceData: deviceDataMap,
+    log: createLog(),
+    config: config || {},
+    deviceType: 'weatherstation',
+    refreshDeviceData(callback) {
+      callback(null, this.deviceData);
+    },
+  };
+}
+
+module.exports = { createNetatmoDeviceStub };

--- a/test-helpers/run-build.js
+++ b/test-helpers/run-build.js
@@ -1,0 +1,17 @@
+'use strict';
+
+function runBuild(device, methodName) {
+  return new Promise((resolve, reject) => {
+    device[methodName]((err, accessories) => {
+      /* eslint-disable-next-line no-undef */
+      clearInterval(device.runCheckInterval);
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(accessories);
+    });
+  });
+}
+
+module.exports = { runBuild };

--- a/test-helpers/scratch-storage-path.js
+++ b/test-helpers/scratch-storage-path.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+function createScratchStoragePath() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'eveatmo-test-'));
+}
+
+module.exports = { createScratchStoragePath };

--- a/test-helpers/stub-axios.js
+++ b/test-helpers/stub-axios.js
@@ -1,0 +1,13 @@
+'use strict';
+
+function stubAxios(fakeAxios) {
+  const modulePath = require.resolve('axios');
+  require.cache[modulePath] = {
+    id: modulePath,
+    filename: modulePath,
+    loaded: true,
+    exports: fakeAxios,
+  };
+}
+
+module.exports = { stubAxios };

--- a/test-helpers/stub-fakegato-history.js
+++ b/test-helpers/stub-fakegato-history.js
@@ -1,0 +1,17 @@
+'use strict';
+
+class NoopFakeGatoHistoryService {
+  addEntry() {}
+}
+
+function stubFakegatoHistory() {
+  const modulePath = require.resolve('fakegato-history');
+  require.cache[modulePath] = {
+    id: modulePath,
+    filename: modulePath,
+    loaded: true,
+    exports: () => NoopFakeGatoHistoryService,
+  };
+}
+
+module.exports = { stubFakegatoHistory };

--- a/test-helpers/wait-for-event.js
+++ b/test-helpers/wait-for-event.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function waitForEvent(emitter, event) {
+  return new Promise((resolve) => {
+    emitter.once(event, (...args) => resolve(args));
+  });
+}
+
+module.exports = { waitForEvent };

--- a/test-helpers/weatherstation-fixture.js
+++ b/test-helpers/weatherstation-fixture.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/* eslint-disable-next-line @typescript-eslint/no-require-imports */
+const fixture = require('../mockapi_calls/getstationsdata-eveatmo.json');
+
+function buildDeviceDataMap() {
+  const station = JSON.parse(JSON.stringify(fixture.body.devices[0]));
+  station._name = station.station_name + ' ' + station.module_name;
+  const map = { [station._id]: station };
+  station.modules.forEach((module) => {
+    module._name = station.station_name + ' ' + module.module_name;
+    map[module._id] = module;
+  });
+  return map;
+}
+
+function findModuleByType(deviceDataMap, type) {
+  return Object.values(deviceDataMap).find((device) => device.type === type);
+}
+
+module.exports = { buildDeviceDataMap, findModuleByType };

--- a/test/accessory/eveatmo-rain-accessory.test.js
+++ b/test/accessory/eveatmo-rain-accessory.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { stubFakegatoHistory } = require('../../test-helpers/stub-fakegato-history');
+stubFakegatoHistory();
+
+const { homebridge, hap } = require('../../test-helpers/hap');
+const { buildDeviceDataMap, findModuleByType } = require('../../test-helpers/weatherstation-fixture');
+const { createNetatmoDeviceStub } = require('../../test-helpers/netatmo-device-stub');
+const { Service, Characteristic } = hap;
+
+const EveatmoRainAccessory = require('../../accessory/eveatmo-rain-accessory')(homebridge);
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+function buildAccessory() {
+  const deviceDataMap = buildDeviceDataMap();
+  const rainModule = findModuleByType(deviceDataMap, 'NAModule3');
+  const netatmoDevice = createNetatmoDeviceStub(deviceDataMap);
+  const accessory = new EveatmoRainAccessory(rainModule, netatmoDevice);
+  return { accessory, deviceDataMap, rainModule };
+}
+
+test('maps rain module data onto the rain service characteristics', () => {
+  const { accessory } = buildAccessory();
+
+  const rainService = accessory.getService(accessory.name);
+  const rainLevel = rainService.getCharacteristic('Rain Level').value;
+  const sum1h = rainService.getCharacteristic('1h').value;
+  const sum24h = rainService.getCharacteristic('24h').value;
+
+  assert.equal(rainLevel, 0);
+  assert.equal(sum1h, 2.5);
+  assert.equal(sum24h, 5);
+});
+
+test('maps rain module battery data onto the Battery service', () => {
+  const { accessory } = buildAccessory();
+
+  const batteryLevel = accessory.getService(Service.Battery).getCharacteristic(Characteristic.BatteryLevel).value;
+  const lowBattery = accessory.getService(Service.Battery).getCharacteristic(Characteristic.StatusLowBattery).value;
+
+  assert.equal(batteryLevel, 21);
+  assert.equal(lowBattery, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+});

--- a/test/accessory/eveatmo-room-accessory.test.js
+++ b/test/accessory/eveatmo-room-accessory.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { stubFakegatoHistory } = require('../../test-helpers/stub-fakegato-history');
+stubFakegatoHistory();
+
+const { homebridge, hap } = require('../../test-helpers/hap');
+const { buildDeviceDataMap, findModuleByType } = require('../../test-helpers/weatherstation-fixture');
+const { createNetatmoDeviceStub } = require('../../test-helpers/netatmo-device-stub');
+const { Service, Characteristic } = hap;
+
+const EveatmoRoomAccessory = require('../../accessory/eveatmo-room-accessory')(homebridge);
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+function buildAccessory(config) {
+  const deviceDataMap = buildDeviceDataMap();
+  const indoorModule = findModuleByType(deviceDataMap, 'NAModule4');
+  const netatmoDevice = createNetatmoDeviceStub(deviceDataMap, config);
+  const accessory = new EveatmoRoomAccessory(indoorModule, netatmoDevice);
+  return { accessory, deviceDataMap, indoorModule };
+}
+
+test('maps indoor module data onto HAP characteristics by default', () => {
+  const { accessory } = buildAccessory({});
+
+  const temperature = accessory.getService(Service.TemperatureSensor).getCharacteristic(Characteristic.CurrentTemperature).value;
+  const humidity = accessory.getService(Service.HumiditySensor).getCharacteristic(Characteristic.CurrentRelativeHumidity).value;
+  const batteryLevel = accessory.getService(Service.Battery).getCharacteristic(Characteristic.BatteryLevel).value;
+
+  assert.ok(Math.abs(temperature - 22.6) < 0.0001, 'temperature should be ~22.6, got ' + temperature);
+  assert.equal(humidity, 63);
+  assert.equal(batteryLevel, 77);
+});
+
+test('does not add CO2 or air-quality services by default', () => {
+  const { accessory } = buildAccessory({});
+
+  assert.equal(accessory.getService(Service.CarbonDioxideSensor), undefined);
+  assert.equal(accessory.getService(Service.AirQualitySensor), undefined);
+});
+
+test('adds CO2 and air-quality services when extra_co2_sensor/extra_aq_sensor are enabled', () => {
+  const { accessory } = buildAccessory({ extra_co2_sensor: true, extra_aq_sensor: true, co2_alert_threshold: 1000 });
+
+  const co2Service = accessory.getService(Service.CarbonDioxideSensor);
+  const airQualityService = accessory.getService(Service.AirQualitySensor);
+
+  const co2Level = co2Service.getCharacteristic(Characteristic.CarbonDioxideLevel).value;
+  const co2Detected = co2Service.getCharacteristic(Characteristic.CarbonDioxideDetected).value;
+  const airQuality = airQualityService.getCharacteristic(Characteristic.AirQuality).value;
+
+  assert.equal(co2Level, 842);
+  assert.equal(co2Detected, Characteristic.CarbonDioxideDetected.CO2_LEVELS_NORMAL);
+  assert.equal(airQuality, Characteristic.AirQuality.GOOD);
+});

--- a/test/accessory/eveatmo-weather-accessory.test.js
+++ b/test/accessory/eveatmo-weather-accessory.test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { stubFakegatoHistory } = require('../../test-helpers/stub-fakegato-history');
+stubFakegatoHistory();
+
+const { homebridge, hap } = require('../../test-helpers/hap');
+const { createLog } = require('../../test-helpers/log');
+const { Service, Characteristic } = hap;
+
+const EveatmoWeatherAccessory = require('../../accessory/eveatmo-weather-accessory')(homebridge);
+
+const fixture = require('../../mockapi_calls/getstationsdata-eveatmo.json');
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+function buildDeviceDataMap() {
+  const station = JSON.parse(JSON.stringify(fixture.body.devices[0]));
+  station._name = station.station_name + ' ' + station.module_name;
+  const map = { [station._id]: station };
+  station.modules.forEach((module) => {
+    module._name = station.station_name + ' ' + module.module_name;
+    map[module._id] = module;
+  });
+  return map;
+}
+
+function findOutdoorModule(deviceDataMap) {
+  return Object.values(deviceDataMap).find((device) => device.type === 'NAModule1');
+}
+
+function createNetatmoDeviceStub(deviceDataMap) {
+  return {
+    deviceData: deviceDataMap,
+    log: createLog(),
+    config: {},
+    deviceType: 'weatherstation',
+    refreshDeviceData(callback) {
+      callback(null, this.deviceData);
+    },
+  };
+}
+
+function buildAccessory() {
+  const deviceDataMap = buildDeviceDataMap();
+  const outdoorModule = findOutdoorModule(deviceDataMap);
+  const netatmoDevice = createNetatmoDeviceStub(deviceDataMap);
+  const accessory = new EveatmoWeatherAccessory(outdoorModule, netatmoDevice);
+  return { accessory, deviceDataMap, outdoorModule };
+}
+
+test('maps outdoor module data onto HAP characteristics on construction', () => {
+  const { accessory } = buildAccessory();
+
+  const temperature = accessory.getService(Service.TemperatureSensor).getCharacteristic(Characteristic.CurrentTemperature).value;
+  const humidity = accessory.getService(Service.HumiditySensor).getCharacteristic(Characteristic.CurrentRelativeHumidity).value;
+
+  assert.ok(Math.abs(temperature - 21.5) < 0.0001, 'temperature should be ~21.5, got ' + temperature);
+  assert.equal(humidity, 76);
+});
+
+test('maps outdoor module battery data onto the Battery service', () => {
+  const { accessory } = buildAccessory();
+
+  const batteryLevel = accessory.getService(Service.Battery).getCharacteristic(Characteristic.BatteryLevel).value;
+  const lowBattery = accessory.getService(Service.Battery).getCharacteristic(Characteristic.StatusLowBattery).value;
+
+  assert.equal(batteryLevel, 91);
+  assert.equal(lowBattery, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+});
+
+test('overrides pressure from the main station on the custom Eve weather characteristic', () => {
+  const { accessory } = buildAccessory();
+
+  const pressureService = accessory.getService(accessory.name + ' Weather Main');
+  const pressure = pressureService.getCharacteristic('Atmospheric Pressure').value;
+
+  assert.equal(pressure, 10071);
+});
+
+test('updates HAP characteristics when notifyUpdate is called again with new data', () => {
+  const { accessory, deviceDataMap, outdoorModule } = buildAccessory();
+
+  const updatedMap = JSON.parse(JSON.stringify(deviceDataMap));
+  updatedMap[outdoorModule._id].dashboard_data.Temperature = 15.2;
+  updatedMap[outdoorModule._id].dashboard_data.Humidity = 60;
+
+  accessory.notifyUpdate(updatedMap);
+
+  const temperature = accessory.getService(Service.TemperatureSensor).getCharacteristic(Characteristic.CurrentTemperature).value;
+  const humidity = accessory.getService(Service.HumiditySensor).getCharacteristic(Characteristic.CurrentRelativeHumidity).value;
+
+  assert.ok(Math.abs(temperature - 15.2) < 0.0001, 'temperature should be ~15.2, got ' + temperature);
+  assert.equal(humidity, 60);
+});

--- a/test/accessory/eveatmo-weather-accessory.test.js
+++ b/test/accessory/eveatmo-weather-accessory.test.js
@@ -8,44 +8,16 @@ const { stubFakegatoHistory } = require('../../test-helpers/stub-fakegato-histor
 stubFakegatoHistory();
 
 const { homebridge, hap } = require('../../test-helpers/hap');
-const { createLog } = require('../../test-helpers/log');
+const { buildDeviceDataMap, findModuleByType } = require('../../test-helpers/weatherstation-fixture');
+const { createNetatmoDeviceStub } = require('../../test-helpers/netatmo-device-stub');
 const { Service, Characteristic } = hap;
 
 const EveatmoWeatherAccessory = require('../../accessory/eveatmo-weather-accessory')(homebridge);
-
-const fixture = require('../../mockapi_calls/getstationsdata-eveatmo.json');
 /* eslint-enable @typescript-eslint/no-require-imports */
-
-function buildDeviceDataMap() {
-  const station = JSON.parse(JSON.stringify(fixture.body.devices[0]));
-  station._name = station.station_name + ' ' + station.module_name;
-  const map = { [station._id]: station };
-  station.modules.forEach((module) => {
-    module._name = station.station_name + ' ' + module.module_name;
-    map[module._id] = module;
-  });
-  return map;
-}
-
-function findOutdoorModule(deviceDataMap) {
-  return Object.values(deviceDataMap).find((device) => device.type === 'NAModule1');
-}
-
-function createNetatmoDeviceStub(deviceDataMap) {
-  return {
-    deviceData: deviceDataMap,
-    log: createLog(),
-    config: {},
-    deviceType: 'weatherstation',
-    refreshDeviceData(callback) {
-      callback(null, this.deviceData);
-    },
-  };
-}
 
 function buildAccessory() {
   const deviceDataMap = buildDeviceDataMap();
-  const outdoorModule = findOutdoorModule(deviceDataMap);
+  const outdoorModule = findModuleByType(deviceDataMap, 'NAModule1');
   const netatmoDevice = createNetatmoDeviceStub(deviceDataMap);
   const accessory = new EveatmoWeatherAccessory(outdoorModule, netatmoDevice);
   return { accessory, deviceDataMap, outdoorModule };

--- a/test/accessory/eveatmo-wind-accessory.test.js
+++ b/test/accessory/eveatmo-wind-accessory.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { stubFakegatoHistory } = require('../../test-helpers/stub-fakegato-history');
+stubFakegatoHistory();
+
+const { homebridge, hap } = require('../../test-helpers/hap');
+const { buildDeviceDataMap, findModuleByType } = require('../../test-helpers/weatherstation-fixture');
+const { createNetatmoDeviceStub } = require('../../test-helpers/netatmo-device-stub');
+const { Service, Characteristic } = hap;
+
+const EveatmoWindAccessory = require('../../accessory/eveatmo-wind-accessory')(homebridge);
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+function buildAccessory() {
+  const deviceDataMap = buildDeviceDataMap();
+  const windModule = findModuleByType(deviceDataMap, 'NAModule2');
+  const netatmoDevice = createNetatmoDeviceStub(deviceDataMap);
+  const accessory = new EveatmoWindAccessory(windModule, netatmoDevice);
+  return { accessory, deviceDataMap, windModule };
+}
+
+test('maps wind module data onto the wind service characteristics', () => {
+  const { accessory } = buildAccessory();
+
+  const windService = accessory.getService(accessory.name + ' Wind Sensor');
+  const windStrength = windService.getCharacteristic('Wind Strength').value;
+  const gustStrength = windService.getCharacteristic('Gust Strength').value;
+  const windAngle = windService.getCharacteristic('Wind Angle').value;
+
+  assert.equal(windStrength, 6);
+  assert.equal(gustStrength, 15);
+  assert.equal(windAngle, 'S');
+});
+
+test('maps wind module battery data onto the Battery service', () => {
+  const { accessory } = buildAccessory();
+
+  const batteryLevel = accessory.getService(Service.Battery).getCharacteristic(Characteristic.BatteryLevel).value;
+  const lowBattery = accessory.getService(Service.Battery).getCharacteristic(Characteristic.StatusLowBattery).value;
+
+  assert.equal(batteryLevel, 97);
+  assert.equal(lowBattery, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+});

--- a/test/device/airquality-device.test.js
+++ b/test/device/airquality-device.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { stubFakegatoHistory } = require('../../test-helpers/stub-fakegato-history');
+stubFakegatoHistory();
+
+const { homebridge } = require('../../test-helpers/hap');
+const { createLog } = require('../../test-helpers/log');
+const { runBuild } = require('../../test-helpers/run-build');
+
+const NetatmoAPIMock = require('../../lib/netatmo-api-mock');
+const AirQualityDeviceType = require('../../device/airquality-device')(homebridge);
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+const NHC_STATION_ID = '70:00:00:01:23:45';
+
+function buildAccessoriesForDevices(config) {
+  const device = new AirQualityDeviceType(createLog(), NetatmoAPIMock('eveatmo'), config);
+  return runBuild(device, 'buildAccessoriesForDevices');
+}
+
+test('maps the NHC (Healthy Home Coach) device to a room accessory', async () => {
+  const accessories = await buildAccessoriesForDevices({ ttl: 300, module_suffix: '' });
+
+  assert.equal(accessories.length, 1);
+  assert.equal(accessories[0].constructor.name, 'EveatmoRoomAccessory');
+  assert.equal(accessories[0].id, NHC_STATION_ID);
+});

--- a/test/device/weatherstation-device.test.js
+++ b/test/device/weatherstation-device.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { stubFakegatoHistory } = require('../../test-helpers/stub-fakegato-history');
+stubFakegatoHistory();
+
+const { homebridge } = require('../../test-helpers/hap');
+const { createLog } = require('../../test-helpers/log');
+
+const NetatmoAPIMock = require('../../lib/netatmo-api-mock');
+const WeatherstationDeviceType = require('../../device/weatherstation-device')(homebridge);
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+const OUTDOOR_MODULE_ID = '02:00:00:01:23:45';
+
+function runBuild(device, methodName) {
+  return new Promise((resolve, reject) => {
+    device[methodName]((err, accessories) => {
+      /* eslint-disable-next-line no-undef */
+      clearInterval(device.runCheckInterval);
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(accessories);
+    });
+  });
+}
+
+function buildAccessoriesForDevices(config) {
+  const device = new WeatherstationDeviceType(createLog(), NetatmoAPIMock('eveatmo'), config);
+  return runBuild(device, 'buildAccessoriesForDevices');
+}
+
+test('maps the outdoor (NAModule1) device to a weather accessory', async () => {
+  const accessories = await buildAccessoriesForDevices({
+    ttl: 300,
+    module_suffix: '',
+    whitelist: [OUTDOOR_MODULE_ID],
+  });
+
+  assert.equal(accessories.length, 1);
+  assert.equal(accessories[0].constructor.name, 'EveatmoWeatherAccessory');
+  assert.equal(accessories[0].id, OUTDOOR_MODULE_ID);
+});
+
+function buildAccessoriesFromDeviceMap(config, deviceMap) {
+  const device = new WeatherstationDeviceType(createLog(), NetatmoAPIMock('eveatmo'), config);
+  device.deviceData = deviceMap;
+  return runBuild(device, 'buildAccessories');
+}
+
+function outdoorModule(id, temperature) {
+  return {
+    _id: id,
+    _name: 'Test Outdoor ' + id,
+    type: 'NAModule1',
+    reachable: true,
+    firmware: 1,
+    dashboard_data: { Temperature: temperature, Humidity: 50 },
+  };
+}
+
+test('whitelist limits accessories to the listed device IDs', async () => {
+  const deviceMap = {
+    'outdoor-1': outdoorModule('outdoor-1', 20),
+    'outdoor-2': outdoorModule('outdoor-2', 18),
+  };
+
+  const accessories = await buildAccessoriesFromDeviceMap(
+    { ttl: 300, module_suffix: '', whitelist: ['outdoor-1'] },
+    deviceMap,
+  );
+
+  assert.equal(accessories.length, 1);
+  assert.equal(accessories[0].id, 'outdoor-1');
+});
+
+test('blacklist excludes the listed device IDs', async () => {
+  const deviceMap = {
+    'outdoor-1': outdoorModule('outdoor-1', 20),
+    'outdoor-2': outdoorModule('outdoor-2', 18),
+  };
+
+  const accessories = await buildAccessoriesFromDeviceMap(
+    { ttl: 300, module_suffix: '', blacklist: ['outdoor-1'] },
+    deviceMap,
+  );
+
+  assert.equal(accessories.length, 1);
+  assert.equal(accessories[0].id, 'outdoor-2');
+});

--- a/test/device/weatherstation-device.test.js
+++ b/test/device/weatherstation-device.test.js
@@ -9,42 +9,36 @@ stubFakegatoHistory();
 
 const { homebridge } = require('../../test-helpers/hap');
 const { createLog } = require('../../test-helpers/log');
+const { runBuild } = require('../../test-helpers/run-build');
 
 const NetatmoAPIMock = require('../../lib/netatmo-api-mock');
 const WeatherstationDeviceType = require('../../device/weatherstation-device')(homebridge);
 /* eslint-enable @typescript-eslint/no-require-imports */
 
+const MAIN_STATION_ID = '70:00:00:01:23:45';
 const OUTDOOR_MODULE_ID = '02:00:00:01:23:45';
-
-function runBuild(device, methodName) {
-  return new Promise((resolve, reject) => {
-    device[methodName]((err, accessories) => {
-      /* eslint-disable-next-line no-undef */
-      clearInterval(device.runCheckInterval);
-      if (err) {
-        reject(err);
-        return;
-      }
-      resolve(accessories);
-    });
-  });
-}
+const WIND_MODULE_ID = '10:00:00:00:00:05';
+const INDOOR_MODULE_ID = '03:00:00:01:23:45';
+const RAIN_MODULE_ID = '05:00:00:01:23:45';
 
 function buildAccessoriesForDevices(config) {
   const device = new WeatherstationDeviceType(createLog(), NetatmoAPIMock('eveatmo'), config);
   return runBuild(device, 'buildAccessoriesForDevices');
 }
 
-test('maps the outdoor (NAModule1) device to a weather accessory', async () => {
-  const accessories = await buildAccessoriesForDevices({
-    ttl: 300,
-    module_suffix: '',
-    whitelist: [OUTDOOR_MODULE_ID],
+test('maps every known Netatmo module type to its matching accessory class', async () => {
+  const accessories = await buildAccessoriesForDevices({ ttl: 300, module_suffix: '' });
+
+  const accessoryClassById = {};
+  accessories.forEach((accessory) => {
+    accessoryClassById[accessory.id] = accessory.constructor.name;
   });
 
-  assert.equal(accessories.length, 1);
-  assert.equal(accessories[0].constructor.name, 'EveatmoWeatherAccessory');
-  assert.equal(accessories[0].id, OUTDOOR_MODULE_ID);
+  assert.equal(accessoryClassById[MAIN_STATION_ID], 'EveatmoRoomAccessory');
+  assert.equal(accessoryClassById[INDOOR_MODULE_ID], 'EveatmoRoomAccessory');
+  assert.equal(accessoryClassById[OUTDOOR_MODULE_ID], 'EveatmoWeatherAccessory');
+  assert.equal(accessoryClassById[WIND_MODULE_ID], 'EveatmoWindAccessory');
+  assert.equal(accessoryClassById[RAIN_MODULE_ID], 'EveatmoRainAccessory');
 });
 
 function buildAccessoriesFromDeviceMap(config, deviceMap) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,80 @@
+'use strict';
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createFakeAxios } = require('../test-helpers/fake-axios');
+const { stubAxios } = require('../test-helpers/stub-axios');
+const { createScratchStoragePath } = require('../test-helpers/scratch-storage-path');
+const { createRecordingLog } = require('../test-helpers/log');
+const { loadPlatform } = require('../test-helpers/load-platform');
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+const fakeAxios = createFakeAxios();
+fakeAxios.post = async () => ({ data: { access_token: 'stub-token' } });
+stubAxios(fakeAxios);
+
+const scratchDir = createScratchStoragePath();
+const EveatmoPlatform = loadPlatform({ user: { storagePath: () => scratchDir } });
+
+function messagesFor(log, level) {
+  return log.calls.filter((call) => call.level === level).map((call) => call.args[0]);
+}
+
+test('missing auth.client_id/client_secret is reported as a bad configuration', () => {
+  const log = createRecordingLog();
+  const platform = new EveatmoPlatform(log, { auth: { client_id: 'cid' } });
+
+  assert.ok(messagesFor(log, 'error').some((msg) => msg.includes('\'client_id\' and \'client_secret\' are mandatory')));
+  assert.equal(platform.api, undefined);
+});
+
+test('an unsupported grant_type is reported as a bad configuration', () => {
+  const log = createRecordingLog();
+  const platform = new EveatmoPlatform(log, {
+    auth: { client_id: 'cid', client_secret: 'secret', grant_type: 'bogus' },
+  });
+
+  assert.ok(messagesFor(log, 'error').some((msg) => msg.includes('Unsupported or missing grant_type')));
+  assert.equal(platform.api, undefined);
+});
+
+test('refresh_token grant without a refresh_token is reported as a bad configuration', () => {
+  const log = createRecordingLog();
+  const platform = new EveatmoPlatform(log, {
+    auth: { client_id: 'cid', client_secret: 'secret', grant_type: 'refresh_token' },
+  });
+
+  assert.ok(messagesFor(log, 'error').some((msg) => msg.includes('\'refresh_token\' not set')));
+  assert.equal(platform.api, undefined);
+});
+
+test('password grant without username/password is reported as a bad configuration', () => {
+  const log = createRecordingLog();
+  const platform = new EveatmoPlatform(log, {
+    auth: { client_id: 'cid', client_secret: 'secret', grant_type: 'password' },
+  });
+
+  assert.ok(messagesFor(log, 'error').some((msg) => msg.includes('\'username\' and \'password\' are mandatory')));
+  assert.equal(platform.api, undefined);
+});
+
+test('a well-formed refresh_token grant config constructs the API client', () => {
+  const log = createRecordingLog();
+  const platform = new EveatmoPlatform(log, {
+    auth: { client_id: 'cid', client_secret: 'secret', grant_type: 'refresh_token', refresh_token: 'rt' },
+  });
+
+  assert.ok(platform.api);
+  assert.equal(messagesFor(log, 'error').length, 0);
+});
+
+test('mockapi config bypasses auth validation and uses the mock API client', () => {
+  const log = createRecordingLog();
+  const platform = new EveatmoPlatform(log, { mockapi: 'eveatmo' });
+
+  assert.ok(messagesFor(log, 'warn').some((msg) => msg.includes('CAUTION! USING FAKE NETATMO API: eveatmo')));
+  assert.ok(platform.api);
+  assert.equal(typeof platform.api.getStationsData, 'function');
+});

--- a/test/lib/netatmo-api-get-healthy-home-coach-data-error.test.js
+++ b/test/lib/netatmo-api-get-healthy-home-coach-data-error.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createFakeAxios } = require('../../test-helpers/fake-axios');
+const { stubAxios } = require('../../test-helpers/stub-axios');
+const { waitForEvent } = require('../../test-helpers/wait-for-event');
+
+const fakeAxios = createFakeAxios();
+stubAxios(fakeAxios);
+
+const netatmo = require('../../lib/netatmo-api');
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+test('getHealthyHomeCoachData calls back with an error when the request fails', async () => {
+  fakeAxios.post = async (url) => {
+    if (url.includes('/oauth2/token')) {
+      return { data: { access_token: 'token-1' } };
+    }
+    throw new Error('unexpected POST ' + url);
+  };
+
+  fakeAxios.get = async () => {
+    const error = new Error('network down');
+    error.response = { status: 500, data: {}, headers: {} };
+    throw error;
+  };
+
+  const client = new netatmo({
+    grant_type: 'password',
+    client_id: 'cid',
+    client_secret: 'secret',
+    username: 'user@example.com',
+    password: 'pw',
+  }, {});
+  client.on('error', () => {});
+  client.on('warning', () => {});
+
+  await waitForEvent(client, 'authenticated');
+
+  const error = await new Promise((resolve) => {
+    client.getHealthyHomeCoachData((err) => resolve(err));
+  });
+
+  assert.ok(error instanceof Error);
+  assert.match(error.message, /getHealthyHomeCoachData error/);
+});

--- a/test/lib/netatmo-api-get-stations-data-error.test.js
+++ b/test/lib/netatmo-api-get-stations-data-error.test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createFakeAxios } = require('../../test-helpers/fake-axios');
+const { stubAxios } = require('../../test-helpers/stub-axios');
+const { waitForEvent } = require('../../test-helpers/wait-for-event');
+
+const fakeAxios = createFakeAxios();
+stubAxios(fakeAxios);
+
+const netatmo = require('../../lib/netatmo-api');
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+test('getStationsData calls back with an error when the request fails', async () => {
+  fakeAxios.post = async (url) => {
+    if (url.includes('/oauth2/token')) {
+      return { data: { access_token: 'token-1' } };
+    }
+    if (url.includes('/api/getstationsdata')) {
+      const error = new Error('network down');
+      error.response = { status: 500, data: {}, headers: {} };
+      throw error;
+    }
+    throw new Error('unexpected POST ' + url);
+  };
+
+  const client = new netatmo({
+    grant_type: 'password',
+    client_id: 'cid',
+    client_secret: 'secret',
+    username: 'user@example.com',
+    password: 'pw',
+  }, {});
+  client.on('error', () => {});
+  client.on('warning', () => {});
+
+  await waitForEvent(client, 'authenticated');
+
+  const error = await new Promise((resolve) => {
+    client.getStationsData((err) => resolve(err));
+  });
+
+  assert.ok(error instanceof Error);
+  assert.match(error.message, /getStationsDataError error/);
+});

--- a/test/lib/netatmo-api-password-grant.test.js
+++ b/test/lib/netatmo-api-password-grant.test.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createFakeAxios } = require('../../test-helpers/fake-axios');
+const { stubAxios } = require('../../test-helpers/stub-axios');
+const { waitForEvent } = require('../../test-helpers/wait-for-event');
+
+const fakeAxios = createFakeAxios();
+stubAxios(fakeAxios);
+
+const netatmo = require('../../lib/netatmo-api');
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+test('password grant: authenticates and fetches healthy home coach data', async () => {
+  fakeAxios.post = async (url, params) => {
+    if (url.includes('/oauth2/token')) {
+      assert.equal(params.get('grant_type'), 'password');
+      assert.equal(params.get('username'), 'user@example.com');
+      return { data: { access_token: 'pw-access-token' } };
+    }
+    throw new Error('unexpected POST ' + url);
+  };
+
+  let capturedUrl = null;
+  fakeAxios.get = async (url) => {
+    capturedUrl = url;
+    return { data: { body: { devices: [{ _id: 'nhc-1' }] } } };
+  };
+
+  const client = new netatmo({
+    grant_type: 'password',
+    client_id: 'cid',
+    client_secret: 'secret',
+    username: 'user@example.com',
+    password: 'pw',
+  }, {});
+  client.on('error', () => {});
+
+  await waitForEvent(client, 'authenticated');
+
+  const devices = await new Promise((resolve, reject) => {
+    client.getHealthyHomeCoachData((err, result) => (err ? reject(err) : resolve(result)));
+  });
+
+  assert.equal(devices.length, 1);
+  assert.equal(devices[0]._id, 'nhc-1');
+  assert.ok(capturedUrl.includes('access_token=pw-access-token'));
+});

--- a/test/lib/netatmo-api-refresh-token-grant-failure.test.js
+++ b/test/lib/netatmo-api-refresh-token-grant-failure.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createFakeAxios } = require('../../test-helpers/fake-axios');
+const { stubAxios } = require('../../test-helpers/stub-axios');
+const { createScratchStoragePath } = require('../../test-helpers/scratch-storage-path');
+const { waitForEvent } = require('../../test-helpers/wait-for-event');
+
+const fakeAxios = createFakeAxios();
+stubAxios(fakeAxios);
+
+const netatmo = require('../../lib/netatmo-api');
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+test('refresh_token grant: surfaces auth failure and getStationsData calls back immediately with an error', async () => {
+  const scratchDir = createScratchStoragePath();
+  const homebridgeStub = { user: { storagePath: () => scratchDir } };
+
+  fakeAxios.post = async (url) => {
+    if (url.includes('/oauth2/token')) {
+      const error = new Error('Request failed');
+      error.response = { status: 400, data: { error: 'invalid_grant' }, headers: {} };
+      throw error;
+    }
+    throw new Error('unexpected POST ' + url);
+  };
+
+  const client = new netatmo({
+    grant_type: 'refresh_token',
+    client_id: 'cid',
+    client_secret: 'secret',
+    refresh_token: 'bad-refresh-token',
+  }, homebridgeStub);
+  client.on('error', () => {});
+
+  await waitForEvent(client, 'authentication-failed');
+
+  const error = await new Promise((resolve) => {
+    client.getStationsData((err) => resolve(err));
+  });
+
+  assert.ok(error instanceof Error);
+});

--- a/test/lib/netatmo-api-refresh-token-grant.test.js
+++ b/test/lib/netatmo-api-refresh-token-grant.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const { createFakeAxios } = require('../../test-helpers/fake-axios');
+const { stubAxios } = require('../../test-helpers/stub-axios');
+const { createScratchStoragePath } = require('../../test-helpers/scratch-storage-path');
+const { waitForEvent } = require('../../test-helpers/wait-for-event');
+
+const fakeAxios = createFakeAxios();
+stubAxios(fakeAxios);
+
+const netatmo = require('../../lib/netatmo-api');
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+test('refresh_token grant: authenticates, persists the new refresh token, and fetches station data', async () => {
+  const scratchDir = createScratchStoragePath();
+  const homebridgeStub = { user: { storagePath: () => scratchDir } };
+
+  let capturedAccessToken = null;
+
+  fakeAxios.post = async (url, params) => {
+    if (url.includes('/oauth2/token')) {
+      assert.equal(params.get('grant_type'), 'refresh_token');
+      assert.equal(params.get('refresh_token'), 'old-refresh-token');
+      return { data: { access_token: 'new-access-token', refresh_token: 'new-refresh-token' } };
+    }
+    if (url.includes('/api/getstationsdata')) {
+      capturedAccessToken = params.get('access_token');
+      return { data: { body: { devices: [{ _id: 'station-1' }] } } };
+    }
+    throw new Error('unexpected POST ' + url);
+  };
+
+  const client = new netatmo({
+    grant_type: 'refresh_token',
+    client_id: 'cid',
+    client_secret: 'secret',
+    refresh_token: 'old-refresh-token',
+  }, homebridgeStub);
+  client.on('error', () => {});
+
+  await waitForEvent(client, 'authenticated');
+
+  const persisted = JSON.parse(fs.readFileSync(path.join(scratchDir, 'netatmo-token.json'), 'utf8'));
+  assert.equal(persisted.refresh_token, 'new-refresh-token');
+  assert.equal(persisted.access_token, undefined);
+
+  const devices = await new Promise((resolve, reject) => {
+    client.getStationsData((err, result) => (err ? reject(err) : resolve(result)));
+  });
+
+  assert.equal(devices.length, 1);
+  assert.equal(devices[0]._id, 'station-1');
+  assert.equal(capturedAccessToken, 'new-access-token');
+});


### PR DESCRIPTION
**Covers the NAModule1 (Outdoor) -> EveatmoWeatherAccessory vertical slice**:
- device-layer mapping/whitelist/blacklist (lib/netatmo-device.js, device/weatherstation-device.js) and accessory-layer notifyUpdate -> HAP characteristic mapping (temperature, humidity, pressure, battery), using Node's built-in node:test runner against the real @homebridge/hap-nodejs. 
- Wires npm test into the existing CI build job.

**Extend test coverage to Room, Rain, Wind accessories and airquality device** 
Second pass building on the initial weatherstation/weather-accessory suite: 
- adds Room accessory tests (including the extra_co2_sensor / extra_aq_sensor config variants), Rain and Wind accessory tests, and an airquality-device test for the NHC -> Room mapping. 
- Extends the weatherstation device-layer test to cover the full module-type -> accessory-class mapping now that all accessory types are exercised.
- Extracts shared test helpers (fixture builder, device stub, build runner) to keep the growing suite DRY.

**Add tests for lib/netatmo-api.js auth lifecycle and index.js config validation**
- Covers both OAuth grant types (refresh_token, password), token persistence (refresh_token only, never access_token, per the existing "may be invalid after restart" comment), and the two methods this
plugin actually calls (getStationsData, getHealthyHomeCoachData) on both success and failure. HTTP is intercepted via a require.cache substitution for axios (same technique as the existing fakegato-history stub), not a new devDependency.
- Adds EveatmoPlatform config-validation coverage in index.js (missing client_id/secret, unsupported grant_type, missing refresh_token / username+password, the mockapi bypass path) via a log-spy helper and a registerPlatform-capturing loader, since the platform class isn't otherwise exported.
-  EveatmoPlatform.accessories() is deliberately not covered end-to-end: the device instances it builds internally start a real, un-unref()'d poll interval with no external handle to clear it, so calling it in a test hangs the process.
- Documented in CLAUDE.md.
